### PR TITLE
FOO-79 update text rotation if edge is top

### DIFF
--- a/lib/button-generator.js
+++ b/lib/button-generator.js
@@ -33,7 +33,7 @@ class ButtonGenerator {
     const angles = {
       right: 270,
       left: 90,
-      top: 0,
+      top: 180,
       bottom: 0
     };
     return angles[this.options.edge] || 0;

--- a/lib/button-svg.js
+++ b/lib/button-svg.js
@@ -35,19 +35,8 @@ class ButtonSVG {
 
   generateBody() {
     return this.virtualDom('g', {}, [
-
       this.generateRectangle(),
-
-      this.virtualDom('text', {
-        fill: this.options.textColor,
-        'font-size': this.options.fontSize,
-      }, [
-        this.virtualDom('tspan', {
-          'y': ButtonSVG.verticalAlign(this.options.height, this.options.fontSize),
-          'x': '50%',
-          'text-anchor': 'middle'
-        }, this.options.text)
-      ])
+      this.virtualDom('text', this.getTextProperties(), this.options.text)
     ]);
   }
 
@@ -63,6 +52,22 @@ class ButtonSVG {
       fill: this.options.backgroundColor,
       d: ButtonSVG.getRectangleBorder(parameters)
     })
+  }
+
+  getTextProperties() {
+    const textProperties = {
+      'fill': this.options.textColor,
+      'font-size': this.options.fontSize,
+      'y': ButtonSVG.verticalAlign(this.options.height, this.options.fontSize),
+      'x': '50%',
+      'text-anchor': 'middle'
+    };
+
+    if (this.options.edge === 'top') {
+      textProperties.transform = ButtonSVG.getInvertedTextRotation(this.options.width, this.options.height);
+    }
+
+    return textProperties;
   }
 
   static getRectangleBorder(parameters) {
@@ -97,6 +102,10 @@ class ButtonSVG {
 
   static getArcTopRight(radius) {
     return `a${radius},${radius} 0 0 1 ${radius},${-radius}`;
+  }
+
+  static getInvertedTextRotation(width, height) {
+    return `rotate(180, ${width / 2}, ${height / 2})`;
   }
 
   static verticalAlign(height, fontSize) {

--- a/test/button-generator.spec.js
+++ b/test/button-generator.spec.js
@@ -80,12 +80,12 @@ describe('ButtonGenerator', function() {
       expect(buttonGenerator.getOrientationAngle()).toEqual(270);
     });
 
-    it('returns 0 if edge property is top', function() {
+    it('returns 180 if edge property is top', function() {
       const options = {
         edge: 'top'
       };
       const buttonGenerator = new ButtonGenerator(options);
-      expect(buttonGenerator.getOrientationAngle()).toEqual(0);
+      expect(buttonGenerator.getOrientationAngle()).toEqual(180);
     });
 
     it('returns 0 if edge property is bottom', function() {

--- a/test/button-svg.spec.js
+++ b/test/button-svg.spec.js
@@ -106,10 +106,31 @@ describe('Button SVG', function() {
       expect(this.rectangle.tagName).toEqual('PATH');
     });
 
-    it('retuns virtual node with two attributes : fill and d', function() {
+    it('returns virtual node with two attributes : fill and d', function() {
       expect(this.rectangle.properties.fill).not.toBeNull();
       expect(this.rectangle.properties.d).not.toBeNull();
     })
+  });
+
+  describe('#getTextProperties', function() {
+    it('returns a text properties object', function() {
+      const expected = {
+        'fill': '#fff',
+        'font-size': 18,
+        'y': 71.75,
+        'x': '50%',
+        'text-anchor': 'middle'
+      }
+      expect(this.buttonSVG.getTextProperties()).toEqual(expected);
+    });
+    it('returns an object with a transform property set to rotate() if edge is top', function() {
+      this.options.edge = 'top';
+      expect(this.buttonSVG.getTextProperties().transform).toMatch(/rotate/);
+    });
+    it('returns an object without a transform property if edge is not top', function() {
+      this.options.edge = 'left';
+      expect(this.buttonSVG.getTextProperties().transform).toBeUndefined();
+    });
   });
 
   describe('::getRectangleBorder', function() {
@@ -196,6 +217,17 @@ describe('Button SVG', function() {
 
     it('returns string which follows the model ax,x 0 0 1 x,-x - Case border radius is null', function() {
       expect(ButtonSVG.getArcTopRight(0)).toEqual('a0,0 0 0 1 0,0');
+    });
+  });
+
+  describe('::getInvertedRotation', function() {
+    it('returns a string with expected transform value', function() {
+      const buttonWidth = 130;
+      const buttonHeight = 40;
+      const expectedX = buttonWidth / 2;
+      const expectedY = buttonHeight / 2;
+      const expected = `rotate(180, ${expectedX}, ${expectedY})`;
+      expect(ButtonSVG.getInvertedTextRotation(buttonWidth, buttonHeight)).toBe(expected);
     });
   });
 


### PR DESCRIPTION
Closes [FED-79](https://usabilla.atlassian.net/browse/FED-79)

Reviewers: @beerecca @dine @pietvanzoen @tjinauyeung 

### Description
Upon compiling the buttons the border radius of the is set to the top left and top right of the button.
However, when the button edge is set to the top, the corners are facing the wrong direction. To fix this issue the text is rotated whenever the edge is set to top.

### Example
![button](https://cloud.githubusercontent.com/assets/10131999/24497636/628b5c44-153c-11e7-9db7-49654e64f98e.png)
