### PR TITLE
chore(npm): npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Button Generator
 ===
 
-This module generates a button image (png format) based on parameters.
+This node module generates a buffer of a button png image based on a set of parameters. It is used in the [Usabilla Themes Publisher](https://github.com/usabilla/themes-publisher) to create feedback buttons.
 
 ## Setup
 ```
@@ -20,7 +20,7 @@ For generating a button we require these properties:
  - A string for the content text of the button - `options.text`
  - A string for the placement position of the button. The available options are: right, left, top, bottom. - `options.edge`
 
- The method `generate(options)` will generate a virtual dom tree buffer.
+ The method `generate(options)` will generate a png buffer.
 
 ## Example
 ```
@@ -38,10 +38,7 @@ const options = {
   edge: 'left'
 };
 const button = new ButtonGenerator(options);
-button.generate()
+button
+  .generate()
+  .then(buffer => console.log(buffer))
 ```
-## Output
-The generate method will generate a virtual dom tree buffer.
-
-
-

--- a/lib/button-generator.js
+++ b/lib/button-generator.js
@@ -15,7 +15,7 @@ class ButtonGenerator {
     const svgObject = buttonSVG.generate();
     const stringSVG = ButtonSVG.stringify(svgObject);
 
-    //Generate a png file based on buffer svg object
+    //Generate a buffer png file based on buffer svg object
     const bufferSVG = Buffer.from(stringSVG.toString());
     return ButtonGenerator.
       svg2png(bufferSVG, {width: this.options.width, height: this.options.height})

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "button-generator",
-  "version": "1.0.0",
-  "private": true,
-  "description": "",
+  "version": "1.0.4",
+  "private": false,
+  "description": "Button Generator ===",
   "main": "index.js",
   "author": "development@usabilla.com",
   "scripts": {
@@ -26,8 +26,20 @@
     "faker": "^3.1.0",
     "jasmine": "^2.5.2",
     "jasmine-spec-reporter": "^3.1.0",
-    "js-styleguide": "git://github.com/usabilla/js-styleguide",
+    "js-styleguide": "git://github.com/usabilla/js-styleguide#v1.0.1",
     "lodash": "^4.12.0",
     "watch": "^1.0.1"
-  }
+  },
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usabilla/button-generator.git"
+  },
+  "bugs": {
+    "url": "https://github.com/usabilla/button-generator/issues"
+  },
+  "homepage": "https://github.com/usabilla/button-generator#readme"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,9 +977,9 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-"js-styleguide@git://github.com/usabilla/js-styleguide":
+"js-styleguide@git://github.com/usabilla/js-styleguide#v1.0.1":
   version "0.0.0-development"
-  resolved "git://github.com/usabilla/js-styleguide#0d768e4e7c108ce59e47dc3db8c0275fcbec08fc"
+  resolved "git://github.com/usabilla/js-styleguide#64d72c2595198c8aafd10549cb51b77ada00a402"
 
 js-tokens@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Related to BUB-95.
Since it is a public package, we don't need to have github keys on docker to be able to install this. Aligned version with current release.

Reviewers: @dine @lcobucci @tzengerink @gPinato @dsantang @beerecca 

## Changelog:
- Now we can do `yarn add button-generator` 🙂 
