### PR TITLE
chore(npm): npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "button-generator",
-  "version": "1.0.0",
-  "private": true,
-  "description": "",
+  "version": "1.0.4",
+  "private": false,
+  "description": "Button Generator ===",
   "main": "index.js",
   "author": "development@usabilla.com",
   "scripts": {
@@ -26,8 +26,20 @@
     "faker": "^3.1.0",
     "jasmine": "^2.5.2",
     "jasmine-spec-reporter": "^3.1.0",
-    "js-styleguide": "git://github.com/usabilla/js-styleguide",
+    "js-styleguide": "git://github.com/usabilla/js-styleguide#v1.0.1",
     "lodash": "^4.12.0",
     "watch": "^1.0.1"
-  }
+  },
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usabilla/button-generator.git"
+  },
+  "bugs": {
+    "url": "https://github.com/usabilla/button-generator/issues"
+  },
+  "homepage": "https://github.com/usabilla/button-generator#readme"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,9 +977,9 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-"js-styleguide@git://github.com/usabilla/js-styleguide":
+"js-styleguide@git://github.com/usabilla/js-styleguide#v1.0.1":
   version "0.0.0-development"
-  resolved "git://github.com/usabilla/js-styleguide#0d768e4e7c108ce59e47dc3db8c0275fcbec08fc"
+  resolved "git://github.com/usabilla/js-styleguide#64d72c2595198c8aafd10549cb51b77ada00a402"
 
 js-tokens@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Related to BUB-95.
Since it is a public package, we don't need to have github keys on docker to be able to install this. Aligned version with current release.

Reviewers: @dine @lcobucci @tzengerink @gPinato @dsantang @beerecca 

## Changelog:
- Point `js-styleguide` package to previous version so we don't have a failing check here (and be able to merge)
- Now we can do `yarn add button-generator` 🙂 
